### PR TITLE
[Lint] Standardize line endings.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Force linux style line endings.
+* text=auto eol=lf

--- a/src/resolver.cpp
+++ b/src/resolver.cpp
@@ -14,6 +14,7 @@
 
 #include <openassetio/Context.hpp>
 #include <openassetio/access.hpp>
+#include <openassetio/errors/exceptions.hpp>
 #include <openassetio/hostApi/HostInterface.hpp>
 #include <openassetio/hostApi/Manager.hpp>
 #include <openassetio/hostApi/ManagerFactory.hpp>
@@ -165,7 +166,7 @@ auto catchAndLogExceptions(Fn &&fn, const openassetio::log::LoggerInterfacePtr &
                            const std::string_view name) {
   try {
     return fn();
-  } catch (const std::exception &exc) {
+  } catch (const openassetio::errors::OpenAssetIOException &exc) {
     std::string msg = "OpenAssetIO error in ";
     msg += name;
     msg += ": ";

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,4 +3,4 @@ pytest==6.2.4
 # run in a forked subprocess. Useful for testing global initialization
 # code paths.
 pytest-forked==1.6.0
-openassetio-manager-bal
+git+https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL.git


### PR DESCRIPTION
https://github.com/OpenAssetIO/OpenAssetIO/issues/1200, explicitly set git behaviour for line endings , ensuring linux style line endings.
We noted in some cases our CI was configured with automatic end of line conversion, which cause some linting problems, especially on windows.